### PR TITLE
V1.2.3 Updates to Filter Command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.PositionContainsKeywordsPredicate;
 /**
  * Parses input arguments and creates a new FilterCommand object
  */
-public class FilterCommandParser {
+public class FilterCommandParser implements Parser<FilterCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the FilterCommand


### PR DESCRIPTION
Resolves #56 issue.

V1.2.3 Updates to Filter Command
- 
- Updated FilterCommandParser to implement parser interface

V1.2.2  Updates to Filter Command
- 
- Bug fix: Entering invalid department or position now shows an error message

V1.2.1 Filter Command
-
- New Command `filter`: Filters the listing of employees to list only employees of the specific department
- `filter` Command usage: filter d/DEPARTMENT or filter r/POSITION or filter d/DEPARTMENT r/POSITION