### PR TITLE
V1.2.4 Testcase for Filter Command

### DIFF
--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,111 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalExpenses.getTypicalExpensesList;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.schedule.TypicalSchedules.getTypicalScheduleList;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
+import seedu.address.model.person.PositionContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FilterCommand}.
+ */
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalExpensesList(),
+            getTypicalScheduleList(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalExpensesList(),
+            getTypicalScheduleList(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void equals() {
+        DepartmentContainsKeywordsPredicate firstDepartmentPredicate =
+                new DepartmentContainsKeywordsPredicate(Collections.singletonList("first"));
+        DepartmentContainsKeywordsPredicate secondDepartmentPredicate =
+                new DepartmentContainsKeywordsPredicate(Collections.singletonList("second"));
+        PositionContainsKeywordsPredicate firstPositionPredicate =
+                new PositionContainsKeywordsPredicate(Collections.singletonList("first"));
+        PositionContainsKeywordsPredicate secondPositionPredicate =
+                new PositionContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FilterCommand filterFirstCommand = new FilterCommand(firstDepartmentPredicate, firstPositionPredicate);
+        FilterCommand filterSecondCommand = new FilterCommand(secondDepartmentPredicate, secondPositionPredicate);
+
+        // same object -> returns true
+        assertTrue(filterFirstCommand.equals(filterFirstCommand));
+
+        // same values -> returns true
+        FilterCommand filterFirstCommandCopy = new FilterCommand(firstDepartmentPredicate, firstPositionPredicate);
+        assertTrue(filterFirstCommand.equals(filterFirstCommandCopy));
+
+        // different type -> returns false
+        assertFalse(filterFirstCommand.equals(1));
+
+        // null -> return false
+        assertFalse(filterFirstCommand.equals(null));
+
+        // different person -> return false
+        assertFalse(filterFirstCommand.equals(filterSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        DepartmentContainsKeywordsPredicate departmentPredicate = prepareDepartmentPredicate(" ");
+        PositionContainsKeywordsPredicate positionPredicate = preparePositionPredicate(" ");
+        FilterCommand command = new FilterCommand(departmentPredicate, positionPredicate);
+        command.setIsPositionPrefixPresent(true);
+        command.setIsDepartmentPrefixPresent(true);
+        expectedModel.updateFilteredPersonList(departmentPredicate.and(positionPredicate));
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 5);
+        DepartmentContainsKeywordsPredicate departmentPredicate = prepareDepartmentPredicate("Human");
+        PositionContainsKeywordsPredicate positionPredicate = preparePositionPredicate("Staff");
+        FilterCommand command = new FilterCommand(departmentPredicate, positionPredicate);
+        command.setIsPositionPrefixPresent(true);
+        command.setIsDepartmentPrefixPresent(true);
+        expectedModel.updateFilteredPersonList(departmentPredicate.and(positionPredicate));
+        assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, CARL, DANIEL, ELLE, FIONA), model.getFilteredPersonList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code DepartmentContainsKeywordsPredicate}.
+     */
+    private DepartmentContainsKeywordsPredicate prepareDepartmentPredicate(String userInput) {
+        return new DepartmentContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code PositionContainsKeywordsPredicate}.
+     */
+    private PositionContainsKeywordsPredicate preparePositionPredicate(String userInput) {
+        return new PositionContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalExpenses.getTypicalExpensesList;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
@@ -82,7 +83,7 @@ public class FilterCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 5);
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 6);
         DepartmentContainsKeywordsPredicate departmentPredicate = prepareDepartmentPredicate("Human");
         PositionContainsKeywordsPredicate positionPredicate = preparePositionPredicate("Staff");
         FilterCommand command = new FilterCommand(departmentPredicate, positionPredicate);
@@ -90,7 +91,7 @@ public class FilterCommandTest {
         command.setIsDepartmentPrefixPresent(true);
         expectedModel.updateFilteredPersonList(departmentPredicate.and(positionPredicate));
         assertCommandSuccess(command, model, commandHistory, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(BENSON, CARL, DANIEL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA), model.getFilteredPersonList());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -6,13 +6,11 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalExpenses.getTypicalExpensesList;
-import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
-import static seedu.address.testutil.TypicalPersons.GEORGE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.schedule.TypicalSchedules.getTypicalScheduleList;
 
@@ -63,7 +61,7 @@ public class FilterCommandTest {
         assertFalse(filterFirstCommand.equals(1));
 
         // null -> return false
-        assertFalse(filterFirstCommand.equals(null));
+        assertFalse(filterFirstCommand == null);
 
         // different person -> return false
         assertFalse(filterFirstCommand.equals(filterSecondCommand));

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -35,7 +35,7 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withEmployeeId("000001").withName("Alice Pauline")
             .withDateOfBirth("12/12/1995").withPhone("94351253").withEmail("alice@example.com")
-            .withDepartment("Human Resource").withPosition("Director").withAddress("123, Jurong West Ave 6, #08-111")
+            .withDepartment("Human Resource").withPosition("Staff").withAddress("123, Jurong West Ave 6, #08-111")
             .withSalary("1000.00").withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withEmployeeId("000001").withName("Benson Meier")
             .withDateOfBirth("12/12/1995").withPhone("98765432").withEmail("johnd@example.com")

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -35,7 +35,7 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withEmployeeId("000001").withName("Alice Pauline")
             .withDateOfBirth("12/12/1995").withPhone("94351253").withEmail("alice@example.com")
-            .withDepartment("Human Resource").withPosition("Staff").withAddress("123, Jurong West Ave 6, #08-111")
+            .withDepartment("Human Resource").withPosition("Director").withAddress("123, Jurong West Ave 6, #08-111")
             .withSalary("1000.00").withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withEmployeeId("000001").withName("Benson Meier")
             .withDateOfBirth("12/12/1995").withPhone("98765432").withEmail("johnd@example.com")
@@ -59,7 +59,7 @@ public class TypicalPersons {
             .withSalary("1000.00").build();
     public static final Person GEORGE = new PersonBuilder().withEmployeeId("000007").withName("George Best")
             .withDateOfBirth("12/12/1995").withPhone("9482442").withEmail("anna@example.com")
-            .withDepartment("Human Resource").withPosition("Staff").withAddress("4th street")
+            .withDepartment("Human Resource").withPosition("Manager").withAddress("4th street")
             .withSalary("1000.00").build();
 
     // Manually added


### PR DESCRIPTION
Resolves #56 issue.

V1.2.4 Testcase for Filter Command
- 
- Added test case for FilterCommand.java

V1.2.3 Updates to Filter Command
- 
- Updated FilterCommandParser to implement parser interface

V1.2.2  Updates to Filter Command
- 
- Bug fix: Entering invalid department or position now shows an error message

V1.2.1 Filter Command
-
- New Command `filter`: Filters the listing of employees to list only employees of the specific department
- `filter` Command usage: filter d/DEPARTMENT or filter r/POSITION or filter d/DEPARTMENT r/POSITION