### PR TITLE
V1.3.2 Schedule command to add leaves

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLeavesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLeavesCommand.java
@@ -61,7 +61,7 @@ public class AddLeavesCommand extends Command {
             }
         }
 
-        if (commit == false) {
+        if (!commit) {
             throw new CommandException(String.format(MESSAGE_PERSON_ALL_ADDED_LEAVE, date));
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddLeavesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLeavesCommand.java
@@ -1,0 +1,79 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE_DATE;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.schedule.Date;
+import seedu.address.model.schedule.Schedule;
+import seedu.address.model.schedule.Type;
+
+/**
+ * Adds a schedule to a employee on the address book.
+ */
+public class AddLeavesCommand extends Command {
+
+    public static final String COMMAND_WORD = "addLeaves";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": schedule leave for all observable employees "
+            + "in the list by specifying the date of company leave. "
+            + "Parameters: "
+            + PREFIX_SCHEDULE_DATE + "[DD/MM/YYYY] "
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_SCHEDULE_DATE + "02/02/2018 ";
+
+    public static final String MESSAGE_SUCCESS = "New Company leaves added: %1$s";
+
+    public static final String MESSAGE_NO_PERSON = "No observable employees found in list! Try to list/find/filter " +
+            "the employees you want to schedule leaves for";
+
+    public static final String MESSAGE_PERSON_ALL_ADDED_LEAVE = "Every observable employees in the list has been " +
+            "added with the leave on %1$s !";
+
+    private final Date date;
+
+    /**
+     * @param date of the company leave to schedule
+     */
+    public AddLeavesCommand(Date date) {
+        requireAllNonNull(date);
+        this.date = date;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        Type leave = new Type(Type.LEAVE);
+        boolean commit = false;
+
+        //model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        if (model.getFilteredPersonList().size() == 0) {
+            throw new CommandException(MESSAGE_NO_PERSON);
+        }
+
+        for (Person person : model.getFilteredPersonList()) {
+            Schedule toAddSchedule = new Schedule(person.getEmployeeId(), leave , date);
+            if (!model.hasSchedule(toAddSchedule)) {
+                model.addSchedule(toAddSchedule);
+                commit = true;
+            }
+        }
+
+        if (commit == false) {
+            throw new CommandException(String.format(MESSAGE_PERSON_ALL_ADDED_LEAVE, date));
+        }
+
+        model.commitScheduleList();
+        return new CommandResult(String.format(MESSAGE_SUCCESS, date));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddLeavesCommand // instanceof handles nulls
+                && date.equals(((AddLeavesCommand) other).date));
+    }
+}
+

--- a/src/main/java/seedu/address/logic/commands/AddLeavesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLeavesCommand.java
@@ -27,11 +27,11 @@ public class AddLeavesCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New Company leaves added: %1$s";
 
-    public static final String MESSAGE_NO_PERSON = "No observable employees found in list! Try to list/find/filter " +
-            "the employees you want to schedule leaves for";
+    public static final String MESSAGE_NO_PERSON = "No observable employees found in list! Try to list/find/filter "
+            + "the employees you want to schedule leaves for";
 
-    public static final String MESSAGE_PERSON_ALL_ADDED_LEAVE = "Every observable employees in the list has been " +
-            "added with the leave on %1$s !";
+    public static final String MESSAGE_PERSON_ALL_ADDED_LEAVE = "Every observable employees in the list has been "
+            + "added with the leave on %1$s !";
 
     private final Date date;
 

--- a/src/main/java/seedu/address/logic/commands/AddWorksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddWorksCommand.java
@@ -62,7 +62,7 @@ public class AddWorksCommand extends Command {
             }
         }
 
-        if (commit == false) {
+        if (!commit) {
             throw new CommandException(String.format(MESSAGE_PERSON_ALL_ADDED_WORK, date));
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddWorksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddWorksCommand.java
@@ -12,40 +12,40 @@ import seedu.address.model.schedule.Schedule;
 import seedu.address.model.schedule.Type;
 
 /**
- * Adds leave schedule to all observable employees on the address book.
+ * Add work schedules to all observable employees on the address book.
  */
-public class AddLeavesCommand extends Command {
+public class AddWorksCommand extends Command {
 
-    public static final String COMMAND_WORD = "addLeaves";
+    public static final String COMMAND_WORD = "addWorks";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": schedule leave for all observable employees "
-            + "in the list by specifying the date of leave to take. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": schedule working schedule for all observable "
+            + "employees in the list by specifying the date to work. "
             + "Parameters: "
             + PREFIX_SCHEDULE_DATE + "[DD/MM/YYYY] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_SCHEDULE_DATE + "02/02/2018 ";
 
-    public static final String MESSAGE_SUCCESS = "New leaves added: %1$s";
+    public static final String MESSAGE_SUCCESS = "New working schedules added: %1$s";
 
     public static final String MESSAGE_NO_PERSON = "No observable employees found in list! Try to list/find/filter "
-            + "the employees you want to schedule leaves for";
+            + "the employees you want to schedule work for";
 
-    public static final String MESSAGE_PERSON_ALL_ADDED_LEAVE = "Every observable employees in the list has been "
-            + "added with the leave on %1$s !";
+    public static final String MESSAGE_PERSON_ALL_ADDED_WORK = "Every observable employees in the list has been "
+            + "added with work on %1$s !";
 
     private final Date date;
 
     /**
-     * @param date of the leave to schedule
+     * @param date of the work to schedule
      */
-    public AddLeavesCommand(Date date) {
+    public AddWorksCommand(Date date) {
         requireAllNonNull(date);
         this.date = date;
     }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
-        Type leave = new Type(Type.LEAVE);
+        Type work = new Type(Type.WORK);
         boolean commit = false;
 
         //model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
@@ -54,15 +54,15 @@ public class AddLeavesCommand extends Command {
         }
 
         for (Person person : model.getFilteredPersonList()) {
-            Schedule toAddSchedule = new Schedule(person.getEmployeeId(), leave , date);
+            Schedule toAddSchedule = new Schedule(person.getEmployeeId(), work , date);
             if (!model.hasSchedule(toAddSchedule)) {
-                model.addSchedule(toAddSchedule);
                 commit = true;
+                model.addSchedule(toAddSchedule);
             }
         }
 
         if (commit == false) {
-            throw new CommandException(String.format(MESSAGE_PERSON_ALL_ADDED_LEAVE, date));
+            throw new CommandException(String.format(MESSAGE_PERSON_ALL_ADDED_WORK, date));
         }
 
         model.commitScheduleList();
@@ -72,8 +72,8 @@ public class AddLeavesCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof AddLeavesCommand // instanceof handles nulls
-                && date.equals(((AddLeavesCommand) other).date));
+                || (other instanceof AddWorksCommand // instanceof handles nulls
+                && date.equals(((AddWorksCommand) other).date));
     }
 }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteLeavesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLeavesCommand.java
@@ -12,33 +12,33 @@ import seedu.address.model.schedule.Schedule;
 import seedu.address.model.schedule.Type;
 
 /**
- * Adds leave schedule to all observable employees on the address book.
+ * Deletes leave schedule to all observable employees on the address book.
  */
-public class AddLeavesCommand extends Command {
+public class DeleteLeavesCommand extends Command {
 
-    public static final String COMMAND_WORD = "addLeaves";
+    public static final String COMMAND_WORD = "deleteLeaves";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": schedule leave for all observable employees "
-            + "in the list by specifying the date of leave to take. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes leave schedules for all observable employees "
+            + "in the list by specifying the date of leave to delete. "
             + "Parameters: "
             + PREFIX_SCHEDULE_DATE + "[DD/MM/YYYY] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_SCHEDULE_DATE + "02/02/2018 ";
 
-    public static final String MESSAGE_SUCCESS = "New leaves added for all observable employees for date: %1$s";
+    public static final String MESSAGE_SUCCESS = "Leaves deleted for all observable employees for date : %1$s";
 
-    public static final String MESSAGE_NO_PERSON = "No observable employees found in list! Try to list/find/filter "
-            + "the employees you want to schedule leaves for";
+    public static final String MESSAGE_NO_PERSON_FOUND = "No observable employees found in list! "
+            + "Try to list/find/filter the employees you want to delete leaves for";
 
-    public static final String MESSAGE_PERSON_ALL_ADDED_LEAVE = "Every observable employees in the list has been "
-            + "added with the leave on %1$s !";
+    public static final String MESSAGE_PERSON_ALL_DELETED_LEAVE = "Every observable employees in the list"
+            + " does not have leave on %1$s !";
 
     private final Date date;
 
     /**
      * @param date of the leave to schedule
      */
-    public AddLeavesCommand(Date date) {
+    public DeleteLeavesCommand(Date date) {
         requireAllNonNull(date);
         this.date = date;
     }
@@ -48,21 +48,20 @@ public class AddLeavesCommand extends Command {
         Type leave = new Type(Type.LEAVE);
         boolean commit = false;
 
-        //model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         if (model.getFilteredPersonList().size() == 0) {
-            throw new CommandException(MESSAGE_NO_PERSON);
+            throw new CommandException(MESSAGE_NO_PERSON_FOUND);
         }
 
         for (Person person : model.getFilteredPersonList()) {
-            Schedule toAddSchedule = new Schedule(person.getEmployeeId(), leave , date);
-            if (!model.hasSchedule(toAddSchedule)) {
-                model.addSchedule(toAddSchedule);
+            Schedule toDeleteSchedule = new Schedule(person.getEmployeeId(), leave , date);
+            if (model.hasSchedule(toDeleteSchedule)) {
+                model.deleteSchedule(toDeleteSchedule);
                 commit = true;
             }
         }
 
         if (commit == false) {
-            throw new CommandException(String.format(MESSAGE_PERSON_ALL_ADDED_LEAVE, date));
+            throw new CommandException(String.format(MESSAGE_PERSON_ALL_DELETED_LEAVE, date));
         }
 
         model.commitScheduleList();
@@ -72,8 +71,8 @@ public class AddLeavesCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof AddLeavesCommand // instanceof handles nulls
-                && date.equals(((AddLeavesCommand) other).date));
+                || (other instanceof DeleteLeavesCommand // instanceof handles nulls
+                && date.equals(((DeleteLeavesCommand) other).date));
     }
 }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteLeavesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLeavesCommand.java
@@ -60,7 +60,7 @@ public class DeleteLeavesCommand extends Command {
             }
         }
 
-        if (commit == false) {
+        if (!commit) {
             throw new CommandException(String.format(MESSAGE_PERSON_ALL_DELETED_LEAVE, date));
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteWorksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteWorksCommand.java
@@ -61,7 +61,7 @@ public class DeleteWorksCommand extends Command {
             }
         }
 
-        if (commit == false) {
+        if (!commit) {
             throw new CommandException(String.format(MESSAGE_PERSON_ALL_DELETED_WORK, date));
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteWorksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteWorksCommand.java
@@ -12,34 +12,34 @@ import seedu.address.model.schedule.Schedule;
 import seedu.address.model.schedule.Type;
 
 /**
- * Add work schedules to all observable employees on the address book.
+ * Deletes working schedule to all observable employees on the address book.
  */
-public class AddWorksCommand extends Command {
+public class DeleteWorksCommand extends Command {
 
-    public static final String COMMAND_WORD = "addWorks";
+    public static final String COMMAND_WORD = "deleteWorks";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": schedule working schedule for all observable "
-            + "employees in the list by specifying the date to work. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes work schedules for all observable employees "
+            + "in the list by specifying the date of work to delete. "
             + "Parameters: "
             + PREFIX_SCHEDULE_DATE + "[DD/MM/YYYY] "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_SCHEDULE_DATE + "02/02/2018 ";
 
-    public static final String MESSAGE_SUCCESS = "New working schedules added for all observable "
-            + "employees for date: %1$s";
+    public static final String MESSAGE_SUCCESS = "Working schedule deleted for all observable "
+            + "employees for date : %1$s";
 
-    public static final String MESSAGE_NO_PERSON = "No observable employees found in list! Try to list/find/filter "
-            + "the employees you want to schedule work for";
+    public static final String MESSAGE_NO_PERSON_FOUND = "No observable employees found in list! "
+            + "Try to list/find/filter the employees you want to delete working schedules for";
 
-    public static final String MESSAGE_PERSON_ALL_ADDED_WORK = "Every observable employees in the list has been "
-            + "added with work on %1$s !";
+    public static final String MESSAGE_PERSON_ALL_DELETED_WORK = "Every observable employees in the list"
+            + " does not have working schedule on %1$s !";
 
     private final Date date;
 
     /**
      * @param date of the work to schedule
      */
-    public AddWorksCommand(Date date) {
+    public DeleteWorksCommand(Date date) {
         requireAllNonNull(date);
         this.date = date;
     }
@@ -49,21 +49,20 @@ public class AddWorksCommand extends Command {
         Type work = new Type(Type.WORK);
         boolean commit = false;
 
-        //model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         if (model.getFilteredPersonList().size() == 0) {
-            throw new CommandException(MESSAGE_NO_PERSON);
+            throw new CommandException(MESSAGE_NO_PERSON_FOUND);
         }
 
         for (Person person : model.getFilteredPersonList()) {
-            Schedule toAddSchedule = new Schedule(person.getEmployeeId(), work , date);
-            if (!model.hasSchedule(toAddSchedule)) {
+            Schedule toDeleteSchedule = new Schedule(person.getEmployeeId(), work , date);
+            if (model.hasSchedule(toDeleteSchedule)) {
                 commit = true;
-                model.addSchedule(toAddSchedule);
+                model.deleteSchedule(toDeleteSchedule);
             }
         }
 
         if (commit == false) {
-            throw new CommandException(String.format(MESSAGE_PERSON_ALL_ADDED_WORK, date));
+            throw new CommandException(String.format(MESSAGE_PERSON_ALL_DELETED_WORK, date));
         }
 
         model.commitScheduleList();
@@ -73,8 +72,8 @@ public class AddWorksCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof AddWorksCommand // instanceof handles nulls
-                && date.equals(((AddWorksCommand) other).date));
+                || (other instanceof DeleteWorksCommand // instanceof handles nulls
+                && date.equals(((DeleteWorksCommand) other).date));
     }
 }
 

--- a/src/main/java/seedu/address/logic/parser/AddLeavesCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLeavesCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.AddLeavesCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import seedu.address.model.schedule.Date;
+
+/**
+ * Parses input arguments and creates a new {@code AddLeavesCommand} object
+ */
+public class AddLeavesCommandParser implements Parser<AddLeavesCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddLeavesCommand
+     * and returns an AddLeavesCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    private String MESSAGE_COMMAND_USAGE_FORMAT = "\nExample: addLeaves 02/02/2018";
+
+    public AddLeavesCommand parse(String args) throws ParseException {
+        try {
+            Date date = ParserUtil.parseDate(args);
+            return new AddLeavesCommand(date);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_DATE_CONSTRAINTS_DEFAULT) +
+                    MESSAGE_COMMAND_USAGE_FORMAT, pe);
+        }
+    }
+
+}
+

--- a/src/main/java/seedu/address/logic/parser/AddLeavesCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLeavesCommandParser.java
@@ -16,16 +16,21 @@ public class AddLeavesCommandParser implements Parser<AddLeavesCommand> {
      * and returns an AddLeavesCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    private String MESSAGE_COMMAND_USAGE_FORMAT = "\nExample: addLeaves 02/02/2018";
+    public static final String MESSAGE_COMMAND_USAGE_FORMAT = "\nExample: addLeaves 02/02/2018";
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddLeavesCommand
+     * and returns an AddLeavesCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public AddLeavesCommand parse(String args) throws ParseException {
         try {
             Date date = ParserUtil.parseDate(args);
             return new AddLeavesCommand(date);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_DATE_CONSTRAINTS_DEFAULT) +
-                    MESSAGE_COMMAND_USAGE_FORMAT, pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_DATE_CONSTRAINTS_DEFAULT)
+                            + MESSAGE_COMMAND_USAGE_FORMAT, pe);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddWorksCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddWorksCommandParser.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.AddWorksCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import seedu.address.model.schedule.Date;
+
+/**
+ * Parses input arguments and creates a new {@code AddLeavesCommand} object
+ */
+public class AddWorksCommandParser implements Parser<AddWorksCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddLeavesCommand
+     * and returns an AddLeavesCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public static final String MESSAGE_COMMAND_USAGE_FORMAT = "\nExample: addWorks 02/02/2018";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddLeavesCommand
+     * and returns an AddLeavesCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AddWorksCommand parse(String args) throws ParseException {
+        try {
+            Date date = ParserUtil.parseDate(args);
+            return new AddWorksCommand(date);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_DATE_CONSTRAINTS_DEFAULT)
+                            + MESSAGE_COMMAND_USAGE_FORMAT, pe);
+        }
+    }
+
+}
+

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddLeavesCommand;
 import seedu.address.logic.commands.AddExpensesCommand;
 import seedu.address.logic.commands.AddRecruitmentPostCommand;
 import seedu.address.logic.commands.AddScheduleCommand;
@@ -109,6 +110,9 @@ public class AddressBookParser {
 
         case AddScheduleCommand.COMMAND_WORD:
             return new AddScheduleCommandParser().parse(arguments);
+
+        case AddLeavesCommand.COMMAND_WORD:
+            return new AddLeavesCommandParser().parse(arguments);
 
         case AddRecruitmentPostCommand.COMMAND_WORD:
             return new AddRecruitmentPostCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.AddExpensesCommand;
 import seedu.address.logic.commands.AddLeavesCommand;
 import seedu.address.logic.commands.AddRecruitmentPostCommand;
 import seedu.address.logic.commands.AddScheduleCommand;
+import seedu.address.logic.commands.AddWorksCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -113,6 +114,9 @@ public class AddressBookParser {
 
         case AddLeavesCommand.COMMAND_WORD:
             return new AddLeavesCommandParser().parse(arguments);
+
+        case AddWorksCommand.COMMAND_WORD:
+            return new AddWorksCommandParser().parse(arguments);
 
         case AddRecruitmentPostCommand.COMMAND_WORD:
             return new AddRecruitmentPostCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,8 +15,10 @@ import seedu.address.logic.commands.AddWorksCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteLeavesCommand;
 import seedu.address.logic.commands.DeleteRecruitmentPostCommand;
 import seedu.address.logic.commands.DeleteScheduleCommand;
+import seedu.address.logic.commands.DeleteWorksCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FilterCommand;
@@ -115,8 +117,14 @@ public class AddressBookParser {
         case AddLeavesCommand.COMMAND_WORD:
             return new AddLeavesCommandParser().parse(arguments);
 
+        case DeleteLeavesCommand.COMMAND_WORD:
+            return new DeleteLeavesCommandParser().parse(arguments);
+
         case AddWorksCommand.COMMAND_WORD:
             return new AddWorksCommandParser().parse(arguments);
+
+        case DeleteWorksCommand.COMMAND_WORD:
+            return new DeleteWorksCommandParser().parse(arguments);
 
         case AddRecruitmentPostCommand.COMMAND_WORD:
             return new AddRecruitmentPostCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,8 +7,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.AddLeavesCommand;
 import seedu.address.logic.commands.AddExpensesCommand;
+import seedu.address.logic.commands.AddLeavesCommand;
 import seedu.address.logic.commands.AddRecruitmentPostCommand;
 import seedu.address.logic.commands.AddScheduleCommand;
 import seedu.address.logic.commands.ClearCommand;

--- a/src/main/java/seedu/address/logic/parser/DeleteLeavesCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteLeavesCommandParser.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.DeleteLeavesCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import seedu.address.model.schedule.Date;
+
+/**
+ * Parses input arguments and creates a new {@code DeleteLeavesCommand} object
+ */
+public class DeleteLeavesCommandParser implements Parser<DeleteLeavesCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteLeavesCommand
+     * and returns an DeleteLeavesCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public static final String MESSAGE_COMMAND_USAGE_FORMAT = "\nExample: deleteLeaves 02/02/2018";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteLeavesCommand
+     * and returns an DeleteLeavesCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteLeavesCommand parse(String args) throws ParseException {
+        try {
+            Date date = ParserUtil.parseDate(args);
+            return new DeleteLeavesCommand(date);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_DATE_CONSTRAINTS_DEFAULT)
+                            + MESSAGE_COMMAND_USAGE_FORMAT, pe);
+        }
+    }
+
+}
+

--- a/src/main/java/seedu/address/logic/parser/DeleteWorksCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteWorksCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.DeleteWorksCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import seedu.address.model.schedule.Date;
+
+/**
+ * Parses input arguments and creates a new {@code DeleteWorksCommand} object
+ */
+public class DeleteWorksCommandParser implements Parser<DeleteWorksCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteWorksCommand
+     * and returns an DeleteWorksCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public static final String MESSAGE_COMMAND_USAGE_FORMAT = "\nExample: deleteWorks 02/02/2018";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteWorksCommand
+     * and returns an DeleteWorksCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteWorksCommand parse(String args) throws ParseException {
+        try {
+            Date date = ParserUtil.parseDate(args);
+            return new DeleteWorksCommand(date);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, Date.MESSAGE_DATE_CONSTRAINTS_DEFAULT)
+                            + MESSAGE_COMMAND_USAGE_FORMAT, pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -106,7 +106,7 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void resetScheduleListData(ReadOnlyScheduleList newData) {
         versionedScheduleList.resetData(newData);
-        indicateAddressBookChanged();
+        indicateScheduleListChanged();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/schedule/Date.java
+++ b/src/main/java/seedu/address/model/schedule/Date.java
@@ -89,7 +89,8 @@ public class Date {
         }
 
         if (("31".equals(day)) && ((
-                "04".equals(month)) || ("06".equals(month)) || ("09".equals(month)) || ("11".equals(month)))) {
+                "04".equals(month)) || ("4".equals(month)) || ("06".equals(month)) || ("6".equals(month)) ||
+                ("09".equals(month)) || ("9".equals(month)) || ("11".equals(month)))) {
             setDateConstraintsError(MESSAGE_DATE_INVALID_MONTH_DATE);
             return false; // april, june, sep, nov does not have 31 days
         }

--- a/src/main/java/seedu/address/model/schedule/Date.java
+++ b/src/main/java/seedu/address/model/schedule/Date.java
@@ -89,8 +89,8 @@ public class Date {
         }
 
         if (("31".equals(day)) && ((
-                "04".equals(month)) || ("4".equals(month)) || ("06".equals(month)) || ("6".equals(month)) ||
-                ("09".equals(month)) || ("9".equals(month)) || ("11".equals(month)))) {
+                "04".equals(month)) || ("4".equals(month)) || ("06".equals(month)) || ("6".equals(month))
+                || ("09".equals(month)) || ("9".equals(month)) || ("11".equals(month)))) {
             setDateConstraintsError(MESSAGE_DATE_INVALID_MONTH_DATE);
             return false; // april, june, sep, nov does not have 31 days
         }

--- a/src/main/java/seedu/address/model/schedule/Type.java
+++ b/src/main/java/seedu/address/model/schedule/Type.java
@@ -15,6 +15,7 @@ public class Type {
      * Type must either be WORK or LEAVE, exact match.
      */
     public static final String TYPE_VALIDATION_REGEX = "(^LEAVE$)|(^WORK$)";
+    public static final String LEAVE = "LEAVE";
 
 
     public final String value;

--- a/src/main/java/seedu/address/model/schedule/Type.java
+++ b/src/main/java/seedu/address/model/schedule/Type.java
@@ -16,6 +16,7 @@ public class Type {
      */
     public static final String TYPE_VALIDATION_REGEX = "(^LEAVE$)|(^WORK$)";
     public static final String LEAVE = "LEAVE";
+    public static final String WORK = "WORK";
 
 
     public final String value;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -7,36 +7,40 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox alignment="CENTER_LEFT" spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="employeeId" text="\$employeeId" styleClass="cell_small_label" />
-      <Label fx:id="dateOfBirth" text="\$dateOfBirth" styleClass="cell_small_label" />
-      <Label fx:id="department" text="\$department" styleClass="cell_small_label" />
-      <Label fx:id="position" text="\$position" styleClass="cell_small_label" />
+      <Label fx:id="employeeId" styleClass="cell_small_label" text="\$employeeId" />
+      <Label fx:id="dateOfBirth" styleClass="cell_small_label" text="\$dateOfBirth" />
+      <Label fx:id="department" styleClass="cell_small_label" text="\$department" />
+      <Label fx:id="position" styleClass="cell_small_label" text="\$position" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="salary" text="\$salary" styleClass="cell_small_label" />
-      <Label fx:id="bonus" text="\$bonus" styleClass="cell_small_label" />
+      <Label fx:id="salary" styleClass="cell_small_label" text="\$salary" />
+      <Label fx:id="bonus" styleClass="cell_small_label" text="\$bonus" />
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -7,40 +7,36 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/10.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
-        <Insets bottom="5" left="15" right="5" top="5" />
+        <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
-      <HBox alignment="CENTER_LEFT" spacing="5">
+      <HBox spacing="5" alignment="CENTER_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="employeeId" styleClass="cell_small_label" text="\$employeeId" />
-      <Label fx:id="dateOfBirth" styleClass="cell_small_label" text="\$dateOfBirth" />
-      <Label fx:id="department" styleClass="cell_small_label" text="\$department" />
-      <Label fx:id="position" styleClass="cell_small_label" text="\$position" />
+      <Label fx:id="employeeId" text="\$employeeId" styleClass="cell_small_label" />
+      <Label fx:id="dateOfBirth" text="\$dateOfBirth" styleClass="cell_small_label" />
+      <Label fx:id="department" text="\$department" styleClass="cell_small_label" />
+      <Label fx:id="position" text="\$position" styleClass="cell_small_label" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <Label fx:id="salary" styleClass="cell_small_label" text="\$salary" />
-      <Label fx:id="bonus" styleClass="cell_small_label" text="\$bonus" />
+      <Label fx:id="salary" text="\$salary" styleClass="cell_small_label" />
+      <Label fx:id="bonus" text="\$bonus" styleClass="cell_small_label" />
     </VBox>
-      <rowConstraints>
-         <RowConstraints />
-      </rowConstraints>
   </GridPane>
 </HBox>


### PR DESCRIPTION
**Milestone 3** 
**V1.3.2 Schedule Command** 
-  **New Command**`addWorks` [dd/mm/yyyy]
    - Adds working schedule for all observable employees in the address book after find/filter/list.
    - Example: addWorks 02/02/2018
-  **New Command**`deleteWorks` [dd/mm/yyyy]
    - Deletes working schedule for all observable employees in the address book after find/filter/list.
    - Example: deleteWorks 02/02/2018
-  **New Command**`addLeaves` [dd/mm/yyyy]
    - Adds leave schedule for all observable employees in the address book after find/filter/list.
    - Example: addLeaves 02/02/2018
-  **New Command**`deleteLeaves` [dd/mm/yyyy]
    - Deletes leave schedule for all observable employees in the address book after find/filter/list.
    - Example: deleteLeaves02/02/2018

**V1.3.1 Schedule Command** 
- **Bug Fix** `delete`, `clear`,  command when `undo` and `redo` are executed. When a person is deleted or cleared, all schedules linked to the person will be deleted as well, undo and redoable.

- Implements Versioned Model List keeps track of the order of commit between Addressbook and ScheduleList for undo and redo to work properly. Can be extended to other Model commits within Model manager.

---
**Milestone 2** 
**V1.2.3 Schedule Command** 
- Test cases updated
- Fixed undo/redo bug for add/delete schedule
- Fixed schedule bug to not allow adding of new schedules when employee id not found
-  **New Command** `deleteSchedule`: [index]
-  **Renamed Command** `schedule` to  `addSchedule` 
-  **Enhanced command** `list`: Lists person and schedules as well.
- **Enhanced command** `delete`: When a person is deleted, all schedules linked to the person will be deleted as well.

**V1.2.2 Schedule Command**.
- Test cases updated
- Fixed date bug

**V1.2.1 Schedule Command**
- Schedule list user interface
- Check Employee Id exists, before allowing the user to add a new schedule with the specified employee id.
- Improved Date model and Type model regular expression check.
- Test case updated
---
**Milestone 1**
**V1.1.3 Schedule Command**
- Add Schedule: Adds a new work or leave schedule for an employee, by date and employee id.
-  **New Command**`Schedule`: schedule id/[6digit] d/[DD/MM/YYYY] t/[WORK/LEAVE] 
- Storage: Stores schedule in ScheduleList.xml
---