### PR TITLE
V1.3.3 New commands: Select Expenses Command and Clear Expenses Command

### DIFF
--- a/src/main/java/seedu/address/commons/events/ui/JumpToListExpensesRequestEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/JumpToListExpensesRequestEvent.java
@@ -1,0 +1,22 @@
+package seedu.address.commons.events.ui;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.events.BaseEvent;
+
+/**
+ * Indicates a request to jump to the list of expenses
+ */
+public class JumpToListExpensesRequestEvent extends BaseEvent {
+
+    public final int targetIndex;
+
+    public JumpToListExpensesRequestEvent(Index targetIndex) {
+        this.targetIndex = targetIndex.getZeroBased();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/ClearExpensesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearExpensesCommand.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.expenses.ExpensesList;
+
+/**
+ * Clears the expenses list.
+ */
+public class ClearExpensesCommand extends Command {
+
+    public static final String COMMAND_WORD = "clearExpenses";
+    public static final String MESSAGE_SUCCESS = "Expenses list has been cleared!";
+    public static final String MESSAGE_FAILURE_CLEARED = "Expenses list is empty! All Expenses are cleared";
+
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        model.updateFilteredExpensesList(model.PREDICATE_SHOW_ALL_EXPENSES);
+        if (model.getFilteredExpensesList().size() > 0) {
+            model.resetDataExpenses(new ExpensesList());
+            model.commitExpensesList();
+        } else {
+            throw new CommandException(MESSAGE_FAILURE_CLEARED);
+        }
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SelectExpensesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectExpensesCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.events.ui.JumpToListExpensesRequestEvent;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.expenses.Expenses;
+
+/**
+ * Selects a expenses identified using it's displayed index from the expenses list.
+ */
+public class SelectExpensesCommand extends Command {
+
+    public static final String COMMAND_WORD = "selectExpenses";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Selects the expenses identified by the index number used in the displayed expenses list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SELECT_EXPENSES_SUCCESS = "Selected Expenses: %1$s";
+
+    private final Index targetIndex;
+
+    public SelectExpensesCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        List<Expenses> filteredExpensesList = model.getFilteredExpensesList();
+
+        if (targetIndex.getZeroBased() >= filteredExpensesList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EXPENSES_DISPLAYED_INDEX);
+        }
+
+        EventsCenter.getInstance().post(new JumpToListExpensesRequestEvent(targetIndex));
+        return new CommandResult(String.format(MESSAGE_SELECT_EXPENSES_SUCCESS, targetIndex.getOneBased()));
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof SelectExpensesCommand // instanceof handles nulls
+                && targetIndex.equals(((SelectExpensesCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.AddRecruitmentPostCommand;
 import seedu.address.logic.commands.AddScheduleCommand;
 import seedu.address.logic.commands.AddWorksCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearExpensesCommand;
 import seedu.address.logic.commands.ClearScheduleCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -31,6 +32,7 @@ import seedu.address.logic.commands.ModifyPayCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.RemoveExpensesCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SelectExpensesCommand;
 import seedu.address.logic.commands.SelectScheduleCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -129,11 +131,17 @@ public class AddressBookParser {
         case DeleteWorksCommand.COMMAND_WORD:
             return new DeleteWorksCommandParser().parse(arguments);
 
+        case SelectExpensesCommand.COMMAND_WORD:
+            return new SelectExpensesCommandParser().parse(arguments);
+
         case SelectScheduleCommand.COMMAND_WORD:
             return new SelectScheduleCommandParser().parse(arguments);
 
         case ClearScheduleCommand.COMMAND_WORD:
             return new ClearScheduleCommand();
+
+        case ClearExpensesCommand.COMMAND_WORD:
+            return new ClearExpensesCommand();
 
         case AddRecruitmentPostCommand.COMMAND_WORD:
             return new AddRecruitmentPostCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/SelectExpensesCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SelectExpensesCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.SelectExpensesCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new SelectExpensesCommand object
+ */
+public class SelectExpensesCommandParser implements Parser<SelectExpensesCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the SelectExpensesCommand
+     * and returns an SelectExpensesCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public SelectExpensesCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new SelectExpensesCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectExpensesCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/ui/ExpensesListPanel.java
+++ b/src/main/java/seedu/address/ui/ExpensesListPanel.java
@@ -2,6 +2,9 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
+import com.google.common.eventbus.Subscribe;
+
+import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -9,6 +12,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.ui.ExpensesPanelSelectionChangedEvent;
+import seedu.address.commons.events.ui.JumpToListExpensesRequestEvent;
 import seedu.address.model.expenses.Expenses;
 
 /**
@@ -41,6 +45,22 @@ public class ExpensesListPanel extends UiPart<Region> {
                         raise(new ExpensesPanelSelectionChangedEvent(newValue));
                     }
                 });
+    }
+
+    /**
+     * Scrolls to the {@code PersonCard} at the {@code index} and selects it.
+     */
+    private void scrollTo(int index) {
+        Platform.runLater(() -> {
+            expensesListView.scrollTo(index);
+            expensesListView.getSelectionModel().clearAndSelect(index);
+        });
+    }
+
+    @Subscribe
+    private void handleJumpToListExpensesRequestEvent(JumpToListExpensesRequestEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        scrollTo(event.targetIndex);
     }
 
     /**


### PR DESCRIPTION
**Milestone 3**
**v1.3.3**
- Added new command, `selectExpenses` command, to allow UI to jump to selected expenses of expenses list
- Added new command, `clearExpenses` command, to clear all expenses of expenses list

**v1.3.2**
- Updated `addExpenses` command to reject if expenses list will result in expenses amount having negative values
- Update on `addExpenses` Command to set expenses amount when adding new expenses to of 2 decimals place

**v1.3.1**
- Created EmployeeIdExpensesContainsKeywordPredicate
- Updated `addExpenses` command to check if employeeId exist in CHRS before adding to expenses list
- Updated `addExpenses` command to add expenses amount to current expenses amount if employeeId exists in expenses list
- Update `delete` command to remove expenses from expenses list of person if person is deleted
- Update `redo` and `undo` command to fix bug

---
**Milestone 2**
**v1.2**
- Added new command `removeex` to remove an individual expenses claim from the expenses list.
- Enhanced commands undo and redo to undo and redo `addex` and `removeex` commands
- Changes `addex` command to `addExpenses` command and `removeex` command to `deleteExpenses` command
- Added test file for addExpenses Command

---
**Milestone 1**
**v1.1**
- Added new storage "Expenses.xml" to store all the expenses claim by employees
- Added new command `addex` to add the expenses claim by employees