### PR TITLE
v1.3.8 Bug fixing

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -108,6 +108,9 @@ Examples:
 
 Available fields: Department, Position
 
+[NOTE]
+Any usage of `filter` command that results in the same prefix appearing more than once will be rejected. Example: filter asc d/Human d/Finance will be rejected.
+
 === Adding employee's data: `add`
 
 Adds employee's data to the database

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -282,14 +282,19 @@ Clear all recruitment posts at one go.
 
 === Locating persons by name: `find`
 
-Find the employee name whose name contain any of the given keywords.
+Find the employee name whose name contains the input keyword or find the employee ID that matches the input keyword.
 
-Format: `find n/NAME`
+Format: `find NAME OR EMPLOYEEID`
 
 Examples:
 
-* `find n/John` +
+* `find John` +
 Find all instances of John
+* `find 000001` +
+Find the employee with employee ID `000001`
+
+[NOTE]
+Usage of `find` command only allows you to find by either name or employee ID.
 
 === View all available functions or commands : `help`
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -77,7 +77,7 @@ public class FilterCommand extends Command {
         Set<String> allDepartments = new HashSet<>();
 
         for (Person department : getFullList) {
-            allDepartments.add(department.getDepartment().toString());
+            allDepartments.add(department.getDepartment().toString().toUpperCase());
         }
 
         String availableDepartments = String.join(", ", allDepartments);
@@ -98,7 +98,7 @@ public class FilterCommand extends Command {
         Set<String> allPositions = new HashSet<>();
 
         for (Person position : getFullList) {
-            allPositions.add(position.getPosition().toString());
+            allPositions.add(position.getPosition().toString().toUpperCase());
         }
 
         String availablePositions = String.join(", ", allPositions);

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -25,9 +25,9 @@ public class FilterCommandParser {
     public static final List<String> ACCEPTED_ORDERS = new ArrayList<>(Arrays.asList(FilterCommand.ASCENDING,
             FilterCommand.DESCENDING));
 
-    private int INDEX_ONE = 0;
-    private int INDEX_TWO = 1;
-    private int INDEX_THREE = 2;
+    private final int INDEX_ONE = 0;
+    private final int INDEX_TWO = 1;
+    private final int INDEX_THREE = 2;
     private char firstPrefix;
     private char secondPrefix;
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.StringTokenizer;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -24,6 +25,12 @@ public class FilterCommandParser {
     public static final List<String> ACCEPTED_ORDERS = new ArrayList<>(Arrays.asList(FilterCommand.ASCENDING,
             FilterCommand.DESCENDING));
 
+    private int INDEX_ONE = 0;
+    private int INDEX_TWO = 1;
+    private int INDEX_THREE = 2;
+    private char firstPrefix;
+    private char secondPrefix;
+
     /**
      * Parses the given {@code String} of arguments in the context of the FilterCommand
      * and returns an FilterCommand object for execution.
@@ -33,13 +40,23 @@ public class FilterCommandParser {
         requireNonNull(args);
 
         String trimmedArgs = args.trim().toLowerCase();
-        String sortOrder = trimmedArgs.split("\\s")[0];
+        String[] trimmedArgsSplit = trimmedArgs.split("\\s");
+        String sortOrder = trimmedArgsSplit[INDEX_ONE];
 
-        if (!ACCEPTED_ORDERS.contains(sortOrder)) {
+        if (trimmedArgsSplit.length >= 3) {
+            String firstArg = trimmedArgsSplit[INDEX_TWO];
+            firstPrefix = firstArg.charAt(INDEX_ONE);
+            String secondArg = trimmedArgsSplit[INDEX_THREE];
+            secondPrefix = secondArg.charAt(INDEX_ONE);
+        }
+
+        if (!ACCEPTED_ORDERS.contains(sortOrder) || trimmedArgsSplit.length > 3
+                || (trimmedArgsSplit.length == 3 && (firstPrefix == secondPrefix))) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DEPARTMENT, PREFIX_POSITION);
+        StringTokenizer st = new StringTokenizer(args);
 
         if (trimmedArgs.isEmpty() || (!argMultimap.getValue(PREFIX_DEPARTMENT).isPresent()
                 && !argMultimap.getValue(PREFIX_POSITION).isPresent())) {

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -25,9 +25,6 @@ public class FilterCommandParser {
     public static final List<String> ACCEPTED_ORDERS = new ArrayList<>(Arrays.asList(FilterCommand.ASCENDING,
             FilterCommand.DESCENDING));
 
-    private final int INDEX_ONE = 0;
-    private final int INDEX_TWO = 1;
-    private final int INDEX_THREE = 2;
     private char firstPrefix;
     private char secondPrefix;
 
@@ -41,13 +38,13 @@ public class FilterCommandParser {
 
         String trimmedArgs = args.trim().toLowerCase();
         String[] trimmedArgsSplit = trimmedArgs.split("\\s");
-        String sortOrder = trimmedArgsSplit[INDEX_ONE];
+        String sortOrder = trimmedArgsSplit[0];
 
         if (trimmedArgsSplit.length >= 3) {
-            String firstArg = trimmedArgsSplit[INDEX_TWO];
-            firstPrefix = firstArg.charAt(INDEX_ONE);
-            String secondArg = trimmedArgsSplit[INDEX_THREE];
-            secondPrefix = secondArg.charAt(INDEX_ONE);
+            String firstArg = trimmedArgsSplit[1];
+            firstPrefix = firstArg.charAt(0);
+            String secondArg = trimmedArgsSplit[2];
+            secondPrefix = secondArg.charAt(0);
         }
 
         if (!ACCEPTED_ORDERS.contains(sortOrder) || trimmedArgsSplit.length > 3

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -125,7 +125,7 @@ public class UniquePersonList implements Iterable<Person> {
         Comparator <Person> nameComparator = new Comparator<Person>() {
             @Override
             public int compare(Person personA, Person personB) {
-                return personA.getName().fullName.compareTo(personB.getName().fullName);
+                return personA.getName().fullName.compareToIgnoreCase(personB.getName().fullName);
             }
         };
 


### PR DESCRIPTION
**Milestone 3**
**v1.3.8**
- Fixed bug where sorting is affected by case
- Fixed bug where there are duplicate listing of department and position when filter command shows 0 person
- Fixed bug where overloaded prefixes is allowed, there should only be one d/ and one r/ 

**v1.3.7**
Resolves #57 issue
- Enhanced command `find`: instead of searching for people by keywords, it now searches for the exact name input by user and/or employee ID input by user
- Updated test files accordingly

**v1.3.6**
- Updated REGEX validation check for department and position fields to accept up to 30 characters maximum
- Updated Name and Email predicate to ignore case
- Padded DOB field with leading zeroes when month and day fall short of 2 numbers
- Fixed listing command whereby after filtering by descending order, list command also shows name in descending order. Ensured that it shows name by ascending order all the time

**v1.3.5**
- New overloaded method `hasPerson(Person person, Predicate<Person> predicate)` to check whether the person exist within a filtered list
- Enhanced command `edit`: When trying to edit email, name & DOB or name & phone to be the same as another person, it will be rejected and GUI will filter to show the person you are trying to duplicate
- Enhanced testing for duplicate person: The system now checks for duplicated employee ID, duplicated email, duplicated phone or duplicated name & date of birth
- Updated test files accordingly

**v1.3.4**
- Enhanced command `filter`: Added listing of available departments and/or positions when the output is "0 persons listed"
- Enhanced command `add`: When trying to add duplicated Person or Employee ID, GUI will filter to show the person you are trying to duplicate
- Removal of redundant predicate files, usage of overloaded constructors within the predicates that require it
- Updated command usage messages
- Updated test files accordingly

**v1.3.3**
- Updated GUI appearance for overall application and PersonCard

**v1.3.2**
- Added sorting to Model such that employees can be sorted in either ascending or descending order by their names.
- New overloaded method `updateFilteredPersonList(Predicate<Person> predicate, String sortOrder)` to apply sorting by employee's name
- Enhanced command `filter`: It now takes in a new argument of either "asc" or "dsc" to decide whether filtered list should be sorted in ascending or descending order.
- `filter` command usage: filter asc/dsc d/DEPARTMENT r/POSITION
- Enhanced command `add`: Duplicated EmployeeIds will now be rejected 
- Enhanced field `DateOfBirth`: Validity check for dates are now available, it only allow dates from the range 01/01/1900 to 31/12/2002 inclusive [Min 16 years old]
- Updated test files accordingly

**v1.3.1**
- Created EmployeeIdContainsKeywordPredicate
- Created EmployeeIdContainsKeywordPredicate test file
- Updated TypicalPersons. typicalPersonAddressBook and PersonBuilder to not have any duplicate employeeIds
- Updated test files accordingly

---
**Milestone 2**
**v1.2**
- New command `filter`: Allows filtering of employees by their Department or Position fields individually
- Enhanced command `filter`: Allows filtering of employees by their Department and Position fields
- Fixed bug where `filter` command throws exception when d/ or r/ is typed without any characters following after the prefix
- Added test files for `filter` command

---
**Milestone 1**
**v1.1**
- New fields, namely EmployeeId, DateOfBirth Department, Position, Salary and Bonus, have been added
- Enhanced command `add`: Compulsory fields added to the command EmployeeId, DateOfBirth, Department, Position and Salary and their prefixes are `id/`, `dob/`, `d/`, `r/` and `s/`
- Enhanced command `edit`: Editing of Department and Position field are now available with theirr prefix `d/` and `r/` respectively