### PR TITLE
V1.4.3 Enhancements

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -36,7 +36,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         requireNonNull(args);
 
         String trimmedArgs = args.trim();
-        String sortOrder = trimmedArgs.split("\\s")[INDEX_ONE];
+        String sortOrder = trimmedArgs.split("\\s")[INDEX_ONE].toLowerCase();
         String[] departmentKeywords = new String[]{""};
         String[] positionKeywords = new String[]{""};
         FilterCommand filterCommand = new FilterCommand(new DepartmentContainsKeywordsPredicate(Arrays

--- a/src/main/java/seedu/address/model/recruitment/JobDescription.java
+++ b/src/main/java/seedu/address/model/recruitment/JobDescription.java
@@ -42,8 +42,8 @@ public class JobDescription {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof Post // instanceof handles nulls
-                && value.equals(((Post) other).value)); // state check
+                || (other instanceof JobDescription // instanceof handles nulls
+                && value.equals(((JobDescription) other).value)); // state check
     }
     @Override
     public int hashCode() {

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -66,6 +66,7 @@ import seedu.address.model.person.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandParserTest {
+    private static final String NEGATIVE_SALARY_DESC = " s/-8000";
     private AddCommandParser parser = new AddCommandParser();
 
     @Test
@@ -266,6 +267,12 @@ public class AddCommandParserTest {
         assertParseFailure(parser, EMPLOYEEID_DESC_BOB + NAME_DESC_BOB + DATEOFBIRTH_DESC_BOB
                 + PHONE_DESC_BOB + EMAIL_DESC_BOB + DEPARTMENT_DESC_BOB + POSITION_DESC_BOB
                 + ADDRESS_DESC_BOB + INVALID_SALARY_DESC
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Salary.MESSAGE_SALARY_CONSTRAINTS);
+
+        // negative salary
+        assertParseFailure(parser, EMPLOYEEID_DESC_BOB + NAME_DESC_BOB + DATEOFBIRTH_DESC_BOB
+                + PHONE_DESC_BOB + EMAIL_DESC_BOB + DEPARTMENT_DESC_BOB + POSITION_DESC_BOB
+                + ADDRESS_DESC_BOB + NEGATIVE_SALARY_DESC
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Salary.MESSAGE_SALARY_CONSTRAINTS);
 
         // invalid tag

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,11 +7,17 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DEPARTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYEEID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_POSITION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MINIMUM_EXPERIENCE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SCHEDULE_YEAR;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.recruitment.RecruitmentBuilder.DEFAULT_JOB_DESCRIPTION;
+import static seedu.address.testutil.recruitment.RecruitmentBuilder.DEFAULT_POST;
+import static seedu.address.testutil.recruitment.RecruitmentBuilder.DEFAULT_WORK_EXP;
 import static seedu.address.testutil.schedule.ScheduleBuilder.DEFAULT_DATE;
 import static seedu.address.testutil.schedule.ScheduleBuilder.DEFAULT_EMPLOYEEID;
 import static seedu.address.testutil.schedule.ScheduleBuilder.DEFAULT_TYPE;
@@ -27,6 +33,7 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddLeavesCommand;
+import seedu.address.logic.commands.AddRecruitmentPostCommand;
 import seedu.address.logic.commands.AddScheduleCommand;
 import seedu.address.logic.commands.AddWorksCommand;
 import seedu.address.logic.commands.CalculateLeavesCommand;
@@ -60,12 +67,14 @@ import seedu.address.model.person.DepartmentContainsKeywordsPredicate;
 import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PositionContainsKeywordsPredicate;
+import seedu.address.model.recruitment.Recruitment;
 import seedu.address.model.schedule.Date;
 import seedu.address.model.schedule.Schedule;
 import seedu.address.model.schedule.Year;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
+import seedu.address.testutil.recruitment.RecruitmentBuilder;
 import seedu.address.testutil.schedule.ScheduleBuilder;
 
 public class AddressBookParserTest {
@@ -320,6 +329,21 @@ public class AddressBookParserTest {
         PositionContainsKeywordsPredicate positionPredicate =
                 new PositionContainsKeywordsPredicate(Collections.singletonList("Intern"));
         assertEquals(new FilterCommand(departmentPredicate, positionPredicate, sortOrder), command);
+    }
+
+    @Test
+    public void parseCommand_addRecruitmentPost() throws Exception {
+        Recruitment recruitment = new RecruitmentBuilder().build();
+        AddRecruitmentPostCommand command = (AddRecruitmentPostCommand) parser.parseCommand(
+                AddRecruitmentPostCommand.COMMAND_WORD + " " + PREFIX_JOB_POSITION + DEFAULT_POST
+                + " " + PREFIX_MINIMUM_EXPERIENCE + DEFAULT_WORK_EXP
+                + " " + PREFIX_JOB_DESCRIPTION + DEFAULT_JOB_DESCRIPTION);
+        assertEquals(new AddRecruitmentPostCommand(recruitment), command);
+        command = (AddRecruitmentPostCommand) parser.parseCommand(
+                AddRecruitmentPostCommand.COMMAND_ALIAS + " " + PREFIX_JOB_POSITION + DEFAULT_POST
+                        + " " + PREFIX_MINIMUM_EXPERIENCE + DEFAULT_WORK_EXP
+                        + " " + PREFIX_JOB_DESCRIPTION + DEFAULT_JOB_DESCRIPTION);
+        assertEquals(new AddRecruitmentPostCommand(recruitment), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -16,14 +16,14 @@ import static seedu.address.testutil.schedule.ScheduleBuilder.DEFAULT_DATE;
 import static seedu.address.testutil.schedule.ScheduleBuilder.DEFAULT_EMPLOYEEID;
 import static seedu.address.testutil.schedule.ScheduleBuilder.DEFAULT_TYPE;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddLeavesCommand;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -16,26 +16,74 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.expenses.ExpensesAmount;
+import seedu.address.model.expenses.MedicalExpenses;
+import seedu.address.model.expenses.MiscellaneousExpenses;
+import seedu.address.model.expenses.TravelExpenses;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Bonus;
+import seedu.address.model.person.DateOfBirth;
+import seedu.address.model.person.Department;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.EmployeeId;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Position;
+import seedu.address.model.person.Salary;
 import seedu.address.model.person.tag.Tag;
+import seedu.address.model.recruitment.JobDescription;
+import seedu.address.model.recruitment.Post;
+import seedu.address.model.recruitment.WorkExp;
+import seedu.address.model.schedule.Date;
+import seedu.address.model.schedule.Type;
+import seedu.address.model.schedule.Year;
 import seedu.address.testutil.Assert;
 
 public class ParserUtilTest {
+    private static final String INVALID_EMPLOYEEID = "00000a";
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_POST = "123456";
+    private static final String INVALID_JOB_DESCRIPTION = "123456";
+    private static final String INVALID_WORK_EXP = "5a";
+    private static final String INVALID_DATE = "01/0A/1995";
+    private static final String INVALID_YEAR = "199A";
+    private static final String INVALID_STATUS = "asd";
+    private static final String INVALID_DATEOFBIRTH = "01/0A/1995";
+    private static final String INVALID_DEPARTMENT = "1234";
+    private static final String INVALID_POSITION = "1234";
+    private static final String INVALID_SALARY = "asd";
+    private static final String INVALID_BONUS = "asd";
+    private static final String INVALID_EXPENSES_AMOUNT = "asd";
+    private static final String INVALID_TRAVEL_EXPENSES = "asd";
+    private static final String INVALID_MEDICAL_EXPENSES = "asd";
+    private static final String INVALID_MISC_EXPENSES = "asd";
 
+    private static final String VALID_EMPLOYEEID = "000000";
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_POST = "IT Manager";
+    private static final String VALID_JOB_DESCRIPTION = "Maintain servers";
+    private static final String VALID_WORK_EXP = "5";
+    private static final String VALID_DATE = "01/01/2019";
+    private static final String VALID_YEAR = "2018";
+    private static final String VALID_STATUS = "LEAVE";
+    private static final String VALID_DATEOFBIRTH = "01/01/1995";
+    private static final String VALID_DEPARTMENT = "Human Resource";
+    private static final String VALID_POSITION = "Intern";
+    private static final String VALID_SALARY = "1234";
+    private static final String VALID_BONUS = "2468";
+    private static final String VALID_EXPENSES_AMOUNT = "1234";
+    private static final String VALID_TRAVEL_EXPENSES = "123";
+    private static final String VALID_MEDICAL_EXPENSES = "123";
+    private static final String VALID_MISC_EXPENSES = "123";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -65,6 +113,192 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseEmployeeId_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseEmployeeId((String) null));
+    }
+
+    @Test
+    public void parseEmployeeId_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseEmployeeId(INVALID_EMPLOYEEID));
+    }
+
+    @Test
+    public void parseEmployeeId_validValueWithoutWhitespace_returnsEmployeeId() throws Exception {
+        EmployeeId expectedEmployeeId = new EmployeeId(VALID_EMPLOYEEID);
+        assertEquals(expectedEmployeeId, ParserUtil.parseEmployeeId(VALID_EMPLOYEEID));
+    }
+
+    @Test
+    public void parseEmployeeId_validValueWithWhitespace_returnsTrimmedEmployeeId() throws Exception {
+        String employeeIdWithWhitespace = WHITESPACE + VALID_EMPLOYEEID + WHITESPACE;
+        EmployeeId expectedEmployeeId = new EmployeeId(VALID_EMPLOYEEID);
+        assertEquals(expectedEmployeeId, ParserUtil.parseEmployeeId(employeeIdWithWhitespace));
+    }
+
+    @Test
+    public void parsePost_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parsePost((String) null));
+    }
+
+    @Test
+    public void parsePost_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parsePost(INVALID_POST));
+    }
+
+    @Test
+    public void parsePost_validValueWithoutWhitespace_returnsPost() throws Exception {
+        Post expectedPost = new Post(VALID_POST);
+        assertEquals(expectedPost, ParserUtil.parsePost(VALID_POST));
+    }
+
+    @Test
+    public void parsePost_validValueWithWhitespace_returnsTrimmedPost() throws Exception {
+        String postWithWhitespace = WHITESPACE + VALID_POST + WHITESPACE;
+        Post expectedPost = new Post(VALID_POST);
+        assertEquals(expectedPost, ParserUtil.parsePost(postWithWhitespace));
+    }
+
+    @Test
+    public void parseJobDescription_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseJobDescription((String) null));
+    }
+
+    @Test
+    public void parseJobDescription_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseJobDescription(INVALID_JOB_DESCRIPTION));
+    }
+
+    @Test
+    public void parseJobDescription_validValueWithoutWhitespace_returnsJobDescription() throws Exception {
+        JobDescription expectedJobDescription = new JobDescription(VALID_JOB_DESCRIPTION);
+        assertEquals(expectedJobDescription, ParserUtil.parseJobDescription(VALID_JOB_DESCRIPTION));
+    }
+
+    @Test
+    public void parseJobDescription_validValueWithWhitespace_returnsTrimmedJobDescription() throws Exception {
+        String jobDescriptionWithWhitespace = WHITESPACE + VALID_JOB_DESCRIPTION + WHITESPACE;
+        JobDescription expectedJobDescription = new JobDescription(VALID_JOB_DESCRIPTION);
+        assertEquals(expectedJobDescription, ParserUtil.parseJobDescription(jobDescriptionWithWhitespace));
+    }
+
+    @Test
+    public void parseWorkExp_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseWorkExp((String) null));
+    }
+
+    @Test
+    public void parseWorkExp_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseWorkExp(INVALID_WORK_EXP));
+    }
+
+    @Test
+    public void parseWorkExp_validValueWithoutWhitespace_returnsWorkExp() throws Exception {
+        WorkExp expectedWorkExp = new WorkExp(VALID_WORK_EXP);
+        assertEquals(expectedWorkExp, ParserUtil.parseWorkExp(VALID_WORK_EXP));
+    }
+
+    @Test
+    public void parseWorkExp_validValueWithWhitespace_returnsTrimmedWorkExp() throws Exception {
+        String workExpWithWhitespace = WHITESPACE + VALID_WORK_EXP + WHITESPACE;
+        WorkExp expectedWorkExp = new WorkExp(VALID_WORK_EXP);
+        assertEquals(expectedWorkExp, ParserUtil.parseWorkExp(workExpWithWhitespace));
+    }
+
+    @Test
+    public void parseDate_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseDate((String) null));
+    }
+
+    @Test
+    public void parseDate_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseDate(INVALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validValueWithoutWhitespace_returnsDate() throws Exception {
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(VALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validValueWithWhitespace_returnsTrimmedDate() throws Exception {
+        String dateWithWhitespace = WHITESPACE + VALID_DATE + WHITESPACE;
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(dateWithWhitespace));
+    }
+
+    @Test
+    public void parseYear_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseYear((String) null));
+    }
+
+    @Test
+    public void parseYear_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseYear(INVALID_YEAR));
+    }
+
+    @Test
+    public void parseYear_validValueWithoutWhitespace_returnsYear() throws Exception {
+        Year expectedYear = new Year(VALID_YEAR);
+        assertEquals(expectedYear, ParserUtil.parseYear(VALID_YEAR));
+    }
+
+    @Test
+    public void parseYear_validValueWithWhitespace_returnsTrimmedYear() throws Exception {
+        String yearWithWhitespace = WHITESPACE + VALID_YEAR + WHITESPACE;
+        Year expectedYear = new Year(VALID_YEAR);
+        assertEquals(expectedYear, ParserUtil.parseYear(yearWithWhitespace));
+    }
+
+    @Test
+    public void parseDates_null_throwsNullPointerException() throws Exception {
+        thrown.expect(NullPointerException.class);
+        ParserUtil.parseDates(null);
+    }
+
+    @Test
+    public void parseDates_collectionWithInvalidDates_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        ParserUtil.parseDates(Arrays.asList(INVALID_DATE));
+    }
+
+    @Test
+    public void parseDates_emptyCollection_returnsEmptySet() throws Exception {
+        assertTrue(ParserUtil.parseDates(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void parseDates_collectionWithValidDates_returnsDateSet() throws Exception {
+        Set<Date> actualDateSet = ParserUtil.parseDates(Arrays.asList(VALID_DATE));
+        Set<Date> expectedDateSet = new HashSet<>(Arrays.asList(new Date(VALID_DATE)));
+
+        assertEquals(expectedDateSet, actualDateSet);
+    }
+
+    @Test
+    public void parseStatus_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseStatus((String) null));
+    }
+
+    @Test
+    public void parseStatus_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseStatus(INVALID_STATUS));
+    }
+
+    @Test
+    public void parseStatus_validValueWithoutWhitespace_returnsStatus() throws Exception {
+        Type expectedStatus = new Type(VALID_STATUS);
+        assertEquals(expectedStatus, ParserUtil.parseStatus(VALID_STATUS));
+    }
+
+    @Test
+    public void parseStatus_validValueWithWhitespace_returnsTrimmedStatus() throws Exception {
+        String statusWithWhitespace = WHITESPACE + VALID_STATUS + WHITESPACE;
+        Type expectedStatus = new Type(VALID_STATUS);
+        assertEquals(expectedStatus, ParserUtil.parseStatus(statusWithWhitespace));
+    }
+
+    @Test
     public void parseName_null_throwsNullPointerException() {
         Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseName((String) null));
     }
@@ -85,6 +319,29 @@ public class ParserUtilTest {
         String nameWithWhitespace = WHITESPACE + VALID_NAME + WHITESPACE;
         Name expectedName = new Name(VALID_NAME);
         assertEquals(expectedName, ParserUtil.parseName(nameWithWhitespace));
+    }
+
+    @Test
+    public void parseDateOfBirth_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseDateOfBirth((String) null));
+    }
+
+    @Test
+    public void parseDateOfBirth_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseDateOfBirth(INVALID_DATEOFBIRTH));
+    }
+
+    @Test
+    public void parseDateOfBirth_validValueWithoutWhitespace_returnsDateOfBirth() throws Exception {
+        DateOfBirth expectedDateOfBirth = new DateOfBirth(VALID_DATEOFBIRTH);
+        assertEquals(expectedDateOfBirth, ParserUtil.parseDateOfBirth(VALID_DATEOFBIRTH));
+    }
+
+    @Test
+    public void parseDateOfBirth_validValueWithWhitespace_returnsTrimmedDateOfBirth() throws Exception {
+        String dateOfBirthWithWhitespace = WHITESPACE + VALID_DATEOFBIRTH + WHITESPACE;
+        DateOfBirth expectedDateOfBirth = new DateOfBirth(VALID_DATEOFBIRTH);
+        assertEquals(expectedDateOfBirth, ParserUtil.parseDateOfBirth(dateOfBirthWithWhitespace));
     }
 
     @Test
@@ -157,6 +414,98 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseDepartment_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseDepartment((String) null));
+    }
+
+    @Test
+    public void parseDepartment_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseDepartment(INVALID_DEPARTMENT));
+    }
+
+    @Test
+    public void parseDepartment_validValueWithoutWhitespace_returnsDepartment() throws Exception {
+        Department expectedDepartment = new Department(VALID_DEPARTMENT);
+        assertEquals(expectedDepartment, ParserUtil.parseDepartment(VALID_DEPARTMENT));
+    }
+
+    @Test
+    public void parseDepartment_validValueWithWhitespace_returnsTrimmedDepartment() throws Exception {
+        String departmentWithWhitespace = WHITESPACE + VALID_DEPARTMENT + WHITESPACE;
+        Department expectedDepartment = new Department(VALID_DEPARTMENT);
+        assertEquals(expectedDepartment, ParserUtil.parseDepartment(departmentWithWhitespace));
+    }
+
+    @Test
+    public void parsePosition_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parsePosition((String) null));
+    }
+
+    @Test
+    public void parsePosition_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parsePosition(INVALID_POSITION));
+    }
+
+    @Test
+    public void parsePosition_validValueWithoutWhitespace_returnsPosition() throws Exception {
+        Position expectedPosition = new Position(VALID_POSITION);
+        assertEquals(expectedPosition, ParserUtil.parsePosition(VALID_POSITION));
+    }
+
+    @Test
+    public void parsePosition_validValueWithWhitespace_returnsTrimmedPosition() throws Exception {
+        String positionWithWhitespace = WHITESPACE + VALID_POSITION + WHITESPACE;
+        Position expectedPosition = new Position(VALID_POSITION);
+        assertEquals(expectedPosition, ParserUtil.parsePosition(positionWithWhitespace));
+    }
+
+    @Test
+    public void parseSalary_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseSalary((String) null));
+    }
+
+    @Test
+    public void parseSalary_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseSalary(INVALID_SALARY));
+    }
+
+    @Test
+    public void parseSalary_validValueWithoutWhitespace_returnsSalary() throws Exception {
+        Salary expectedSalary = new Salary(VALID_SALARY);
+        assertEquals(expectedSalary, ParserUtil.parseSalary(VALID_SALARY));
+    }
+
+    @Test
+    public void parseSalary_validValueWithWhitespace_returnsTrimmedSalary() throws Exception {
+        String salaryWithWhitespace = WHITESPACE + VALID_SALARY + WHITESPACE;
+        Salary expectedSalary = new Salary(VALID_SALARY);
+        assertEquals(expectedSalary, ParserUtil.parseSalary(salaryWithWhitespace));
+    }
+
+    @Test
+    public void parseBonus_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseBonus((String) null));
+    }
+
+    @Test
+    public void parseBonus_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseBonus(INVALID_BONUS));
+    }
+
+    @Test
+    public void parseBonus_validValueWithoutWhitespace_returnsBonus() throws Exception {
+        Bonus expectedBonus = new Bonus(VALID_BONUS);
+        assertEquals(expectedBonus, ParserUtil.parseBonus(VALID_BONUS));
+    }
+
+    @Test
+    public void parseBonus_validValueWithWhitespace_returnsTrimmedBonus() throws Exception {
+        String bonusWithWhitespace = WHITESPACE + VALID_BONUS + WHITESPACE;
+        Bonus expectedBonus = new Bonus(VALID_BONUS);
+        assertEquals(expectedBonus, ParserUtil.parseBonus(bonusWithWhitespace));
+    }
+
+    @Test
     public void parseTag_null_throwsNullPointerException() throws Exception {
         thrown.expect(NullPointerException.class);
         ParserUtil.parseTag(null);
@@ -204,5 +553,97 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseExpensesAmount_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseExpensesAmount((String) null));
+    }
+
+    @Test
+    public void parseExpensesAmount_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseExpensesAmount(INVALID_EXPENSES_AMOUNT));
+    }
+
+    @Test
+    public void parseExpensesAmount_validValueWithoutWhitespace_returnsExpensesAmount() throws Exception {
+        ExpensesAmount expectedExpensesAmount = new ExpensesAmount(VALID_EXPENSES_AMOUNT);
+        assertEquals(expectedExpensesAmount, ParserUtil.parseExpensesAmount(VALID_EXPENSES_AMOUNT));
+    }
+
+    @Test
+    public void parseExpensesAmount_validValueWithWhitespace_returnsTrimmedExpensesAmount() throws Exception {
+        String expensesAmountWithWhitespace = WHITESPACE + VALID_EXPENSES_AMOUNT + WHITESPACE;
+        ExpensesAmount expectedExpensesAmount = new ExpensesAmount(VALID_EXPENSES_AMOUNT);
+        assertEquals(expectedExpensesAmount, ParserUtil.parseExpensesAmount(expensesAmountWithWhitespace));
+    }
+
+    @Test
+    public void parseTravelExpenses_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseTravelExpenses((String) null));
+    }
+
+    @Test
+    public void parseTravelExpenses_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseTravelExpenses(INVALID_TRAVEL_EXPENSES));
+    }
+
+    @Test
+    public void parseTravelExpenses_validValueWithoutWhitespace_returnsTravelExpenses() throws Exception {
+        TravelExpenses expectedTravelExpenses = new TravelExpenses(VALID_TRAVEL_EXPENSES);
+        assertEquals(expectedTravelExpenses, ParserUtil.parseTravelExpenses(VALID_TRAVEL_EXPENSES));
+    }
+
+    @Test
+    public void parseTravelExpenses_validValueWithWhitespace_returnsTrimmedTravelExpenses() throws Exception {
+        String travelExpensesWithWhitespace = WHITESPACE + VALID_TRAVEL_EXPENSES + WHITESPACE;
+        TravelExpenses expectedTravelExpenses = new TravelExpenses(VALID_TRAVEL_EXPENSES);
+        assertEquals(expectedTravelExpenses, ParserUtil.parseTravelExpenses(travelExpensesWithWhitespace));
+    }
+
+    @Test
+    public void parseMedicalExpenses_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseMedicalExpenses((String) null));
+    }
+
+    @Test
+    public void parseMedicalExpenses_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseMedicalExpenses(INVALID_MEDICAL_EXPENSES));
+    }
+
+    @Test
+    public void parseMedicalExpenses_validValueWithoutWhitespace_returnsMedicalExpenses() throws Exception {
+        MedicalExpenses expectedMedicalExpenses = new MedicalExpenses(VALID_MEDICAL_EXPENSES);
+        assertEquals(expectedMedicalExpenses, ParserUtil.parseMedicalExpenses(VALID_MEDICAL_EXPENSES));
+    }
+
+    @Test
+    public void parseMedicalExpenses_validValueWithWhitespace_returnsTrimmedMedicalExpenses() throws Exception {
+        String medicalExpensesWithWhitespace = WHITESPACE + VALID_MEDICAL_EXPENSES + WHITESPACE;
+        MedicalExpenses expectedMedicalExpenses = new MedicalExpenses(VALID_MEDICAL_EXPENSES);
+        assertEquals(expectedMedicalExpenses, ParserUtil.parseMedicalExpenses(medicalExpensesWithWhitespace));
+    }
+
+    @Test
+    public void parseMiscellaneousExpenses_null_throwsNullPointerException() {
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseMiscellaneousExpenses((String) null));
+    }
+
+    @Test
+    public void parseMiscellaneousExpenses_invalidValue_throwsParseException() {
+        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseMiscellaneousExpenses(INVALID_MISC_EXPENSES));
+    }
+
+    @Test
+    public void parseMiscellaneousExpenses_validValueWithoutWhitespace_returnsMiscellaneousExpenses() throws Exception {
+        MiscellaneousExpenses expectedMiscellaneousExpenses = new MiscellaneousExpenses(VALID_MISC_EXPENSES);
+        assertEquals(expectedMiscellaneousExpenses, ParserUtil.parseMiscellaneousExpenses(VALID_MISC_EXPENSES));
+    }
+
+    @Test
+    public void parseMiscellaneousExpenses_validValueWithWhitespace_returnsTrimmedBonus() throws Exception {
+        String miscExpensesWithWhitespace = WHITESPACE + VALID_MISC_EXPENSES + WHITESPACE;
+        MiscellaneousExpenses expectedMiscellaneousExpenses = new MiscellaneousExpenses(VALID_MISC_EXPENSES);
+        assertEquals(expectedMiscellaneousExpenses, ParserUtil.parseMiscellaneousExpenses(miscExpensesWithWhitespace));
     }
 }

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -11,6 +11,9 @@ import static seedu.address.ui.testutil.GuiTestAssert.assertCardEquals;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
 
@@ -91,16 +94,31 @@ public class PersonListPanelTest extends GuiUnitTest {
      */
     private Path createXmlFileWithPersons(int personCount) throws Exception {
         StringBuilder builder = new StringBuilder();
-        String nameStr = "a";
+        char[] alphabets = IntStream.rangeClosed('a', 'z')
+                .mapToObj(c -> "" + (char) c).collect(Collectors.joining()).toCharArray();
+        int j = 0, k = 3, l = 0, year = 1900;
+        String[] nameStr = new String[]{"aaa", "aba", "aca", "ada"};
         builder.append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
         builder.append("<addressbook>\n");
         for (int i = 0; i < personCount; i++) {
             builder.append("<persons>\n");
             String employeeIdFormatted = String.format("%06d", i);
             builder.append("<employeeId>" + employeeIdFormatted + "</employeeId>\n");
-            nameStr += "a";
-            builder.append("<name>").append(nameStr).append("a</name>\n");
-            builder.append("<dateOfBirth>12/12/1995</dateOfBirth>\n");
+            builder.append("<name>").append(nameStr[l]).append("</name>\n");
+            if ((i + 1) % 100 == 0) {
+                j++;
+                nameStr[l] = nameStr[l].substring(0, k - 1);
+                nameStr[l] += alphabets[j];
+            }
+            if ((i + 1) % 2500 == 0) {
+                j = 0;
+                l++;
+            }
+            builder.append("<dateOfBirth>12/12/" + year + "</dateOfBirth>\n");
+            if (year == 2000) {
+                year = 1900;
+            }
+            year++;
             String phoneFormatted = String.format("00%d", i);
             builder.append("<phone>" + phoneFormatted + "</phone>\n");
             String emailFormatted = String.format("a%d@aa", i);

--- a/src/test/java/seedu/address/ui/PersonListPanelTest.java
+++ b/src/test/java/seedu/address/ui/PersonListPanelTest.java
@@ -11,7 +11,6 @@ import static seedu.address.ui.testutil.GuiTestAssert.assertCardEquals;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -96,7 +95,10 @@ public class PersonListPanelTest extends GuiUnitTest {
         StringBuilder builder = new StringBuilder();
         char[] alphabets = IntStream.rangeClosed('a', 'z')
                 .mapToObj(c -> "" + (char) c).collect(Collectors.joining()).toCharArray();
-        int j = 0, k = 3, l = 0, year = 1900;
+        int j = 0;
+        int k = 3;
+        int l = 0;
+        int year = 1900;
         String[] nameStr = new String[]{"aaa", "aba", "aca", "ada"};
         builder.append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n");
         builder.append("<addressbook>\n");


### PR DESCRIPTION
**Milestone 4**
**v1.4.3**
- Enhanced command `filter`: It now accepts order of sorting in a case-insensitive manner, i.e. you can type ASC, DsC, etc instead of just asc or dsc

**Test Files Updates**
- PersonListPanelTest
- ParserUtilTest
- AddressBookParserTest
- AddCommandParserTest

**v1.4.2**
- Enhanced command `find`: It now shows schedule and expenses of the person(s) found 

**Test Files Updates**
- FilterCommandTest
- FilterCommandParserTest
- FindCommandTest
- AddressBookParserTest
- ClearCommandTest
- DeleteCommandTest
- UniquePersonListTest
- PersonTest
- AddressTest
- BonusTest
- DateOfBirthTest
- DepartmentTest
- EmailTest
- EmployeeIdTest
- NameTest
- PhoneTest
- PositionTest 
- SalaryTest

**v1.4.1**
Resolved #197.
- Removed duplicated Q&A in UserGuide.adoc & updated feature command formats.
- Removed unused command and unused methods/constructors within certain classes
- Edited `add` and `edit` command to show only 1 person when duplicate is found
- Updated salary's message constraints 
- Ensured that person, schedules and expenses list are always sorted in ascending order by the employee's name, employeeId respectively. 
- Fixed `add` and `edit` command to not allow overloaded prefixes 
- Refactored FilterCommand.java, FilterCommandParser.java codes 
---
**Milestone 3**
**v1.3**
-	Enhanced command `filter`: It will now take in a new argument of either “asc” or “dsc” to decide whether employees in the filtered list should be sorted in ascending or descending order (by their name)
-- Command Usage: filter asc/dsc d/DEPARTMENT r/POSITION
-	Enhanced command `filter`: Added listing of currently available departments and/or positions when the output is "0 persons listed"
-	Enhanced command `find`: It now searches for exact name keyword by user and/or employee Id input by user. Therefore, when typing “find alex tan” instead of searching for names that include alex or tan, it now searches for names that include “alex tan” as a whole
-	Enhanced command `add`: Duplicated EmployeeIds, Email or Phone will now be rejected alongside duplicated Name & DateOfBirth and when attempting to do so, GUI will filter to show the person you are trying to duplicate
-	Enhanced command `edit`: When the edit causes duplicated Email or Phone or Name & DateOfBirth, the command will be rejected, and GUI will filter to show the person you are trying to duplicate
-	Enhanced method `isSamePerson`: It will now check for duplicate EmployeeId, Email, Phone, or Name & DateOfBirth 
-	Enhanced field `DateOfBirth`: Validity check for dates are now available, it only allows dates from the range of 01/01/1900 to 31/12/2002 inclusive and it accepts input such as 1/1/1900 instead of forcing the user to type 01/01/1900 to be accepted
-	Enhanced field `Department`: It will now accept only 2 to 30 characters
-	Enhanced field `Position: It will now accept only 2 to 30 characters
-	Fixed bug whereby overloaded prefix is allowed in `filter` command
-	Fixed bug whereby the sort argument in `filter` command is affected by case
-	Fixed bug whereby duplicate listing of department and position appears when `filter` command shows 0 person listed
-	Fixed bug whereby filtering by descending order causes list to also show every employee in the system in descending name order
-	Minor updates to GUI overall appearance and fields within PersonCard
---
**Milestone 2**
**v1.2**
- New command `filter`: Allows filtering of employees by their Department or Position fields individually
- Enhanced command `filter`: Allows filtering of employees by their Department and Position fields
- Fixed bug where `filter` command throws exception when d/ or r/ is typed without any characters following after the prefix
- Added test files for `filter` command
---
**Milestone 1**
**v1.1**
- New fields, namely EmployeeId, DateOfBirth Department, Position, Salary and Bonus, have been added
- Enhanced command `add`: Compulsory fields added to the command EmployeeId, DateOfBirth, Department, Position and Salary and their prefixes are `id/`, `dob/`, `d/`, `r/` and `s/`
- Enhanced command `edit`: Editing of Department and Position field are now available with theirr prefix `d/` and `r/` respectively